### PR TITLE
extract lastAccount from swap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jup-ag/instruction-parser",
-  "version": "6.0.18",
+  "version": "6.0.19",
   "description": "Parser to parse instruction on the Jupiter v4 program.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ export type SwapAttributes = {
   feeAmountInUSD?: number;
   feeMint?: string;
   tokenLedger?: string;
+  lastAccount: string; // This can be a tracking account since we don't have a way to know we just log it the last account.
 };
 
 const reduceEventData = <T>(events: Event[], name: string) =>
@@ -147,10 +148,11 @@ export async function extract(
 
   const swap = {} as SwapAttributes;
 
-  const [instructionName, transferAuthority] =
-    parser.getInstructionNameAndTransferAuthority(instructions);
+  const [instructionName, transferAuthority, lastAccount] =
+    parser.getInstructionNameAndTransferAuthorityAndLastAccount(instructions);
 
   swap.transferAuthority = transferAuthority;
+  swap.lastAccount = lastAccount;
   swap.instruction = instructionName;
   swap.owner = tx.transaction.message.accountKeys[0].pubkey.toBase58();
   swap.programId = programId.toBase58();

--- a/src/lib/instruction-parser.ts
+++ b/src/lib/instruction-parser.ts
@@ -12,7 +12,9 @@ export class InstructionParser {
     this.coder = new BorshCoder(IDL);
   }
 
-  getInstructionNameAndTransferAuthority(instructions: PartialInstruction[]) {
+  getInstructionNameAndTransferAuthorityAndLastAccount(
+    instructions: PartialInstruction[]
+  ) {
     for (const instruction of instructions) {
       if (!instruction.programId.equals(this.programId)) {
         continue;
@@ -26,8 +28,10 @@ export class InstructionParser {
           instruction.accounts[
             this.getTransferAuthorityIndex(instructionName)
           ].toString();
+        const lastAccount =
+          instruction.accounts[instruction.accounts.length - 1].toString();
 
-        return [ix.name, transferAuthority];
+        return [ix.name, transferAuthority, lastAccount];
       }
     }
 


### PR DESCRIPTION
last account of a swap can be used as a tracking account. since there is no way for us to know now, we just always record the last account.