### PR TITLE
fix: change price api to v2

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,7 +21,7 @@ export async function getPriceInUSDByMint(
     }
 
     let payload = (await got
-      .get(`https://price.jup.ag/v4/price?ids=${tokenMint}`)
+      .get(`https://api.jup.ag/price/v2?ids=${tokenMint}`)
       .json()) as any;
 
     if (payload.data[tokenMint]) {


### PR DESCRIPTION
## What's changed
- price api `price.jup.ag` was deprecated
- changed to new price api v2 `api.jup.ag/price/v2`